### PR TITLE
Fix the release parameters

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,6 +27,11 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
+    files:
+      - 'CHANGELOG.md'
+      - 'LICENSE-APACHE'
+      - 'LICENSE-MIT'
+      - 'README.md'
 
 checksum:
   name_template: 'checksums.txt'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,12 +23,6 @@ archives:
   - id: 'mmdbinspect'
     builds:
       - 'mmdbinspect'
-    replacements:
-      darwin: 'Darwin'
-      linux: 'Linux'
-      windows: 'Windows'
-      386: 'i386'
-      amd64: 'x86_64'
     wrap_in_directory: true
     format_overrides:
       - goos: windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
-## 0.0.0 (2020-02-10)
+## 0.1.1 (2020-02-18)
+
+* Fix release config
+* Add release instructions
+
+## 0.1.0 (2020-02-18)
 
 * Initial beta release

--- a/README.dev.md
+++ b/README.dev.md
@@ -1,0 +1,13 @@
+# Releasing
+
+* Install `goreleaser`. Refer to its docs.
+* Set a `GITHUB_TOKEN` environment variable. Refer to `goreleaser` docs for
+  information.
+* Update `CHANGELOG.md`.
+  * Mention recent changes.
+  * Set a version if there is not one.
+  * Set a release date.
+* Commit `CHANGELOG.md`.
+* Tag the release: `git tag -a v1.2.3 -m 'Tag v1.2.3'`.
+* Push the tag: `git push origin v1.2.3`.
+* Run `goreleaser`.


### PR DESCRIPTION
Somehow the `replacements` key was not deleted, and the releases were named using those replacement keys. We'll want to fix that as soon as possible.