### PR TITLE
Use go install instead of go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ _We aim always to support the current and penultimate major releases of the Go c
 The easiest way is via `go get`:
 
 ```bash
-$ go get -u github.com/maxmind/mmdbinspect/cmd/mmdbinspect
+$ go install github.com/maxmind/mmdbinspect/cmd/mmdbinspect
 ```
 
 This installs `mmdbinspect` to `$GOPATH/bin/mmdbinspect`.


### PR DESCRIPTION
mmdbinspect instructions are updated to use "go install" instead of "go get". PT ID: #183421622