### PR TITLE
Add option to skip aliased networks

### DIFF
--- a/cmd/mmdbinspect/main.go
+++ b/cmd/mmdbinspect/main.go
@@ -25,7 +25,7 @@ func (i *arrayFlags) Set(value string) error {
 
 func usage() {
 	fmt.Printf(
-		"Usage: %s [-skipAliasedNetworks] -db path/to/db -db path/to/other/db 130.113.64.30/24 0:0:0:0:0:ffff:8064:a678\n",
+		"Usage: %s [-skipAliasedNetworks] -db path/to/db -db path/to/other/db 130.113.64.30/24 0:0:0:0:0:ffff:8064:a678\n", //nolint: lll
 		os.Args[0],
 	)
 	flag.PrintDefaults()
@@ -40,7 +40,10 @@ func main() {
 	var mmdb arrayFlags
 
 	flag.Var(&mmdb, "db", "Path to an mmdb file. You may pass this arg more than once.")
-	skipAliasedNetworks := flag.Bool("skipAliasedNetworks", false, "Skip aliased networks (e.g. 6to4, Teredo). Ensures that IPv4 networks are only listed once.")
+	skipAliasedNetworks := flag.Bool(
+		"skipAliasedNetworks", false,
+		"Skip aliased networks (e.g. 6to4, Teredo). Ensures that IPv4 networks are only listed once.",
+	)
 
 	flag.Usage = usage
 	flag.Parse()

--- a/cmd/mmdbinspect/main.go
+++ b/cmd/mmdbinspect/main.go
@@ -25,7 +25,7 @@ func (i *arrayFlags) Set(value string) error {
 
 func usage() {
 	fmt.Printf(
-		"Usage: %s [-skip-aliased-networks=true] -db path/to/db -db path/to/other/db 130.113.64.30/24 0:0:0:0:0:ffff:8064:a678\n", //nolint: lll
+		"Usage: %s [-include-aliased-networks] -db path/to/db -db path/to/other/db 130.113.64.30/24 0:0:0:0:0:ffff:8064:a678\n", //nolint: lll
 		os.Args[0],
 	)
 	flag.PrintDefaults()
@@ -40,9 +40,9 @@ func main() {
 	var mmdb arrayFlags
 
 	flag.Var(&mmdb, "db", "Path to an mmdb file. You may pass this arg more than once.")
-	skipAliasedNetworks := flag.Bool(
-		"skip-aliased-networks", true,
-		"Skip aliased networks (e.g. 6to4, Teredo). Ensures that IPv4 networks are only listed once.",
+	includeAliasedNetworks := flag.Bool(
+		"include-aliased-networks", false,
+		"Include aliased networks (e.g. 6to4, Teredo). This option may cause IPv4 networks to be listed more than once via aliases.", //nolint: lll
 	)
 
 	flag.Usage = usage
@@ -63,7 +63,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	records, err := mmdbinspect.AggregatedRecords(network, mmdb, *skipAliasedNetworks)
+	records, err := mmdbinspect.AggregatedRecords(network, mmdb, *includeAliasedNetworks)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/mmdbinspect/main.go
+++ b/cmd/mmdbinspect/main.go
@@ -25,7 +25,7 @@ func (i *arrayFlags) Set(value string) error {
 
 func usage() {
 	fmt.Printf(
-		"Usage: %s [-skipAliasedNetworks] -db path/to/db -db path/to/other/db 130.113.64.30/24 0:0:0:0:0:ffff:8064:a678\n", //nolint: lll
+		"Usage: %s [-skip-aliased-networks=true] -db path/to/db -db path/to/other/db 130.113.64.30/24 0:0:0:0:0:ffff:8064:a678\n", //nolint: lll
 		os.Args[0],
 	)
 	flag.PrintDefaults()
@@ -41,7 +41,7 @@ func main() {
 
 	flag.Var(&mmdb, "db", "Path to an mmdb file. You may pass this arg more than once.")
 	skipAliasedNetworks := flag.Bool(
-		"skipAliasedNetworks", false,
+		"skip-aliased-networks", true,
 		"Skip aliased networks (e.g. 6to4, Teredo). Ensures that IPv4 networks are only listed once.",
 	)
 

--- a/cmd/mmdbinspect/main.go
+++ b/cmd/mmdbinspect/main.go
@@ -25,7 +25,7 @@ func (i *arrayFlags) Set(value string) error {
 
 func usage() {
 	fmt.Printf(
-		"Usage: %s -db path/to/db -db path/to/other/db 130.113.64.30/24 0:0:0:0:0:ffff:8064:a678\n",
+		"Usage: %s [-skipAliasedNetworks] -db path/to/db -db path/to/other/db 130.113.64.30/24 0:0:0:0:0:ffff:8064:a678\n",
 		os.Args[0],
 	)
 	flag.PrintDefaults()
@@ -40,6 +40,7 @@ func main() {
 	var mmdb arrayFlags
 
 	flag.Var(&mmdb, "db", "Path to an mmdb file. You may pass this arg more than once.")
+	skipAliasedNetworks := flag.Bool("skipAliasedNetworks", false, "Skip aliased networks (e.g. 6to4, Teredo). Ensures that IPv4 networks are only listed once.")
 
 	flag.Usage = usage
 	flag.Parse()
@@ -59,7 +60,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	records, err := mmdbinspect.AggregatedRecords(network, mmdb)
+	records, err := mmdbinspect.AggregatedRecords(network, mmdb, *skipAliasedNetworks)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/mmdbinspect/mmdbinspect.go
+++ b/pkg/mmdbinspect/mmdbinspect.go
@@ -46,7 +46,7 @@ func OpenDB(path string) (*maxminddb.Reader, error) {
 // RecordsForNetwork fetches mmdb records inside a given network.  If an
 // address is provided without a netmask a /32 will be inferred for v4
 // addresses and a /128 will be inferred for v6 addresses.
-func RecordsForNetwork(reader maxminddb.Reader, maybeNetwork string) (any, error) {
+func RecordsForNetwork(reader maxminddb.Reader, skipAliasedNetworks bool, maybeNetwork string) (any, error) {
 	lookupNetwork := maybeNetwork
 
 	if !strings.Contains(lookupNetwork, "/") {
@@ -63,7 +63,12 @@ func RecordsForNetwork(reader maxminddb.Reader, maybeNetwork string) (any, error
 		return nil, fmt.Errorf("%v is not a valid IP address", maybeNetwork)
 	}
 
-	n := reader.NetworksWithin(network)
+	var n *maxminddb.Networks
+	if skipAliasedNetworks {
+		n = reader.NetworksWithin(network, maxminddb.SkipAliasedNetworks)
+	} else {
+		n = reader.NetworksWithin(network)
+	}
 
 	var found []any
 
@@ -86,7 +91,7 @@ func RecordsForNetwork(reader maxminddb.Reader, maybeNetwork string) (any, error
 
 // AggregatedRecords returns the aggregated records for the networks and
 // databases provided.
-func AggregatedRecords(networks, databases []string) (any, error) {
+func AggregatedRecords(networks, databases []string, skipAliasedNetworks bool) (any, error) {
 	recordSets := make([]RecordSet, 0)
 
 	for _, path := range databases {
@@ -97,7 +102,7 @@ func AggregatedRecords(networks, databases []string) (any, error) {
 
 		for _, thisNetwork := range networks {
 			var records any
-			records, err = RecordsForNetwork(*reader, thisNetwork)
+			records, err = RecordsForNetwork(*reader, skipAliasedNetworks, thisNetwork)
 
 			if err != nil {
 				_ = reader.Close()

--- a/pkg/mmdbinspect/mmdbinspect.go
+++ b/pkg/mmdbinspect/mmdbinspect.go
@@ -46,7 +46,7 @@ func OpenDB(path string) (*maxminddb.Reader, error) {
 // RecordsForNetwork fetches mmdb records inside a given network.  If an
 // address is provided without a netmask a /32 will be inferred for v4
 // addresses and a /128 will be inferred for v6 addresses.
-func RecordsForNetwork(reader maxminddb.Reader, skipAliasedNetworks bool, maybeNetwork string) (any, error) {
+func RecordsForNetwork(reader maxminddb.Reader, includeAliasedNetworks bool, maybeNetwork string) (any, error) {
 	lookupNetwork := maybeNetwork
 
 	if !strings.Contains(lookupNetwork, "/") {
@@ -64,10 +64,10 @@ func RecordsForNetwork(reader maxminddb.Reader, skipAliasedNetworks bool, maybeN
 	}
 
 	var n *maxminddb.Networks
-	if skipAliasedNetworks {
-		n = reader.NetworksWithin(network, maxminddb.SkipAliasedNetworks)
-	} else {
+	if includeAliasedNetworks {
 		n = reader.NetworksWithin(network)
+	} else {
+		n = reader.NetworksWithin(network, maxminddb.SkipAliasedNetworks)
 	}
 
 	var found []any
@@ -91,7 +91,7 @@ func RecordsForNetwork(reader maxminddb.Reader, skipAliasedNetworks bool, maybeN
 
 // AggregatedRecords returns the aggregated records for the networks and
 // databases provided.
-func AggregatedRecords(networks, databases []string, skipAliasedNetworks bool) (any, error) {
+func AggregatedRecords(networks, databases []string, includeAliasedNetworks bool) (any, error) {
 	recordSets := make([]RecordSet, 0)
 
 	for _, path := range databases {
@@ -102,7 +102,7 @@ func AggregatedRecords(networks, databases []string, skipAliasedNetworks bool) (
 
 		for _, thisNetwork := range networks {
 			var records any
-			records, err = RecordsForNetwork(*reader, skipAliasedNetworks, thisNetwork)
+			records, err = RecordsForNetwork(*reader, includeAliasedNetworks, thisNetwork)
 
 			if err != nil {
 				_ = reader.Close()

--- a/pkg/mmdbinspect/mmdbinspect_test.go
+++ b/pkg/mmdbinspect/mmdbinspect_test.go
@@ -50,19 +50,19 @@ func TestRecordsForNetwork(t *testing.T) {
 	reader, err := OpenDB(CityDBPath) // ipv6 database
 	a.NoError(err, "no open error")
 
-	records, err := RecordsForNetwork(*reader, "81.2.69.142")
+	records, err := RecordsForNetwork(*reader, false, "81.2.69.142")
 	a.NoError(err, "no error on lookup of 81.2.69.142")
 	a.NotNil(records, "records returned")
 
-	records, err = RecordsForNetwork(*reader, "81.2.69.0/24")
+	records, err = RecordsForNetwork(*reader, false, "81.2.69.0/24")
 	a.NoError(err, "no error on lookup of 81.2.69.0/24")
 	a.NotNil(records, "records returned")
 
-	records, err = RecordsForNetwork(*reader, "10.255.255.255/29")
+	records, err = RecordsForNetwork(*reader, false, "10.255.255.255/29")
 	a.NoError(err, "got no error when IP not found")
 	a.Nil(records, "no records returned for 10.255.255.255/29")
 
-	records, err = RecordsForNetwork(*reader, "X.X.Y.Z")
+	records, err = RecordsForNetwork(*reader, false, "X.X.Y.Z")
 	a.Error(err, "got an error")
 	a.Nil(records, "no records returned for X.X.Y.Z")
 	a.Equal("X.X.Y.Z is not a valid IP address", err.Error())
@@ -75,7 +75,7 @@ func TestRecordToString(t *testing.T) {
 
 	reader, err := OpenDB(CityDBPath)
 	a.NoError(err, "no open error")
-	records, err := RecordsForNetwork(*reader, "81.2.69.142")
+	records, err := RecordsForNetwork(*reader, false, "81.2.69.142")
 	a.NoError(err, "no RecordsForNetwork error")
 	prettyJSON, err := RecordToString(records)
 
@@ -92,7 +92,7 @@ func TestAggregatedRecords(t *testing.T) {
 
 	dbs := []string{CityDBPath, CountryDBPath}
 	networks := []string{"81.2.69.142", "8.8.8.8"}
-	results, err := AggregatedRecords(networks, dbs)
+	results, err := AggregatedRecords(networks, dbs, false)
 
 	a.NoError(err)
 	a.NotNil(results)


### PR DESCRIPTION
The new `-skipAliasedNetworks` flag will remove aliases of the IPv4 address space (e.g. Teredo, 6to4) from the IPv6 results in the output.