### PR TITLE
Turn off optional escaping of ampersand and angle brackets

### DIFF
--- a/pkg/mmdbinspect/mmdbinspect.go
+++ b/pkg/mmdbinspect/mmdbinspect.go
@@ -2,6 +2,7 @@
 package mmdbinspect
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -120,10 +121,15 @@ func AggregatedRecords(networks, databases []string, includeAliasedNetworks bool
 
 // RecordToString converts an mmdb record into a JSON-formatted string.
 func RecordToString(record any) (string, error) {
-	j, err := json.MarshalIndent(record, "", "    ")
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false) // don't escape ampersands and angle brackets
+	enc.SetIndent("", "    ")
+
+	err := enc.Encode(record)
 	if err != nil {
 		return "", errors.New("could not convert record to string")
 	}
 
-	return string(j), nil
+	return buf.String(), nil
 }

--- a/pkg/mmdbinspect/mmdbinspect_test.go
+++ b/pkg/mmdbinspect/mmdbinspect_test.go
@@ -11,6 +11,7 @@ import (
 const (
 	CityDBPath    = "../../test/data/test-data/GeoIP2-City-Test.mmdb"
 	CountryDBPath = "../../test/data/test-data/GeoIP2-Country-Test.mmdb"
+	ISPDBPath     = "../../test/data/test-data/GeoIP2-ISP-Test.mmdb"
 )
 
 func TestOpenDB(t *testing.T) {
@@ -83,6 +84,24 @@ func TestRecordToString(t *testing.T) {
 	a.NotNil(prettyJSON, "records stringified")
 	a.Contains(prettyJSON, "London")
 	a.Contains(prettyJSON, "2643743")
+
+	require.NoError(t, reader.Close())
+}
+
+// TestRecordToStringEscaping tests that certain HTML-related characters are not
+// escaped in the JSON output.
+func TestRecordToStringEscaping(t *testing.T) {
+	a := assert.New(t)
+
+	reader, err := OpenDB(ISPDBPath)
+	a.NoError(err, "no open error")
+	records, err := RecordsForNetwork(*reader, false, "206.16.137.0/24")
+	a.NoError(err, "no RecordsForNetwork error")
+	prettyJSON, err := RecordToString(records)
+
+	a.NoError(err, "no error on stringification")
+	a.NotNil(prettyJSON, "records stringified")
+	a.Contains(prettyJSON, "AT&T Synaptic Cloud Hosting")
 
 	require.NoError(t, reader.Close())
 }


### PR DESCRIPTION
By default, Go's `json` marshaller will [escape angle brackets and ampersands](https://pkg.go.dev/encoding/json#Marshal). We want to disable this for more readable output, escaping only as required by the [JSON specification](https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf).