### PR TITLE
Remove deprecated property from goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,11 +55,15 @@ nfpms:
       - 'deb'
       - 'rpm'
     bindir: '/usr/bin'
-    files:
-      'CHANGELOG.md': '/usr/share/doc/mmdbinspect/CHANGELOG.md'
-      'LICENSE-APACHE': '/usr/share/doc/mmdbinspect/LICENSE-APACHE'
-      'LICENSE-MIT': '/usr/share/doc/mmdbinspect/LICENSE-MIT'
-      'README.md': '/usr/share/doc/mmdbinspect/README.md'
+    contents:
+      - src: 'CHANGELOG.md'
+        dst: '/usr/share/doc/mmdbinspect/CHANGELOG.md'
+      - src: 'LICENSE-APACHE'
+        dst: '/usr/share/doc/mmdbinspect/LICENSE-APACHE'
+      - src: 'LICENSE-MIT'
+        dst: '/usr/share/doc/mmdbinspect/LICENSE-MIT'
+      - src: 'README.md'
+        dst: '/usr/share/doc/mmdbinspect/README.md'
 
 release:
   target_commitish: "{{ .FullCommit }}"


### PR DESCRIPTION
The `files` property was [replaced with](https://goreleaser.com/deprecations/#nfpmsfiles) `contents` a couple years ago.